### PR TITLE
Avoid methods introduced in elixir 1.15

### DIFF
--- a/lib/http_cookie.ex
+++ b/lib/http_cookie.ex
@@ -90,7 +90,7 @@ defmodule HttpCookie do
   @spec expired?(cookie :: t()) :: boolean()
   @spec expired?(cookie :: t(), now :: DateTime.t()) :: boolean()
   def expired?(cookie, now \\ DateTime.utc_now()) do
-    DateTime.after?(now, cookie.expiry_time)
+    DateTime.compare(now, cookie.expiry_time) == :gt
   end
 
   # 5.4.  The Cookie Header

--- a/lib/http_cookie/jar.ex
+++ b/lib/http_cookie/jar.ex
@@ -244,7 +244,7 @@ defmodule HttpCookie.Jar do
       rhs_path_size = byte_size(rhs_cookie.path)
 
       if lhs_path_size == rhs_path_size do
-        DateTime.before?(lhs_cookie.creation_time, rhs_cookie.creation_time)
+        DateTime.compare(lhs_cookie.creation_time, rhs_cookie.creation_time) == :lt
       else
         lhs_path_size > rhs_path_size
       end

--- a/lib/http_cookie/parser.ex
+++ b/lib/http_cookie/parser.ex
@@ -138,10 +138,10 @@ defmodule HttpCookie.Parser do
     case DateParser.parse(val) do
       {:ok, dt} ->
         cond do
-          DateTime.after?(dt, latest_expiry_time()) ->
+          DateTime.compare(dt, latest_expiry_time()) == :gt ->
             {"Expires", latest_expiry_time()}
 
-          DateTime.before?(dt, earliest_expiry_time()) ->
+          DateTime.compare(dt, earliest_expiry_time()) == :lt ->
             {"Expires", earliest_expiry_time()}
 
           true ->

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule HttpCookie.MixProject do
     [
       app: :http_cookie,
       version: @version,
-      elixir: "~> 1.15",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       description: description(),
       package: package(),

--- a/test/http_cookie/jar_test.exs
+++ b/test/http_cookie/jar_test.exs
@@ -302,7 +302,7 @@ defmodule HttpCookie.JarTest do
         |> Map.values()
         |> hd()
 
-      assert DateTime.after?(updated_cookie.last_access_time, ~U[2024-04-01 12:00:00Z])
+      assert DateTime.compare(updated_cookie.last_access_time, ~U[2024-04-01 12:00:00Z]) == :gt
     end
   end
 

--- a/test/http_cookie/req_test.exs
+++ b/test/http_cookie/req_test.exs
@@ -58,7 +58,7 @@ defmodule HttpCookie.ReqTest do
       |> Map.fetch!({"foo", "/"})
       |> Map.fetch!(:last_access_time)
 
-    assert DateTime.after?(updated_access_time, original_access_time)
+    assert DateTime.compare(updated_access_time, original_access_time) == :gt
   end
 
   test "picks up cookies from redirect response" do


### PR DESCRIPTION
This allows continued elixir 1.14 support.  Can be reverted once that release is end-of-life.

See #4