### PR TITLE
feat: add req plugin support jar server

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ req =
 %{private: %{cookie_jar: updated_jar}} = Req.get!(req, url: "/two", cookie_jar: updated_jar)
 ```
 
+You can also use a server to manage the cookies jar with `HttpCookie.ReqServerPlugin`:
+
+```elixir
+{:ok, server_pid} = HttpCookie.Jar.Server.start_link()
+
+req =
+  Req.new(base_url: "https://example.com")
+  |> HttpCookie.ReqServerPlugin.attach(jar_server: server_pid)
+
+Req.get!(req, url: "/one")
+```
+
 ### Usage with `Tesla`
 
 HttpCookie can be used with [Tesla](https://github.com/elixir-tesla/tesla) to automatically set and parse cookies in HTTP requests:

--- a/lib/http_cookie/req_server_plugin.ex
+++ b/lib/http_cookie/req_server_plugin.ex
@@ -1,0 +1,84 @@
+if Code.ensure_loaded?(Req) do
+  defmodule HttpCookie.ReqServerPlugin do
+    @moduledoc """
+    Automatically manages cookies using http_cookie with a cookie jar server.
+    """
+
+    @doc """
+    Attaches the plugin to the request pipeline.
+
+    ## Request Options
+
+      * `:jar_server` - HttpCookie.Jar.Server instance pid (required)
+
+    ## Examples
+
+        {:ok, server_pid} = HttpCookie.Jar.Server.start_link([])
+        client = Req.new(url: "http://httpbun.com") |> HttpCookie.ReqServerPlugin.attach(jar_server: server_pid)
+
+    """
+    @spec attach(Req.Request.t(), opts :: keyword()) :: Req.Request.t()
+    def attach(%Req.Request{} = request, options \\ []) do
+      request
+      |> Req.Request.register_options([:jar_server])
+      |> Req.Request.merge_options(options)
+      |> Req.Request.append_request_steps(add_cookies: &add_cookies/1)
+      |> Req.Request.prepend_response_steps(update_cookies: &update_cookies/1)
+    end
+
+    defp add_cookies(%{options: %{jar_server: jar_server}} = request) when jar_server != nil do
+      {request, original_cookie_header} =
+        if Req.Request.get_private(request, :req_redirect_count, 0) == 0 do
+          original_header =
+            request
+            |> Req.Request.get_header("cookie")
+            |> List.first()
+
+          request =
+            Req.Request.put_private(request, :http_cookie_orig_cookie_header, original_header)
+
+          {request, original_header}
+        else
+          {request, Req.Request.get_private(request, :http_cookie_orig_cookie_header)}
+        end
+
+      case HttpCookie.Jar.Server.get_cookie_header_value(jar_server, request.url) do
+        {:ok, value} ->
+          # only set the cookie header if the user didn't originally set it
+          if original_cookie_header do
+            request
+          else
+            Req.Request.put_header(request, "cookie", value)
+          end
+
+        {:error, :no_matching_cookies} ->
+          request
+      end
+    end
+
+    defp add_cookies(request), do: request
+
+    defp update_cookies({%{options: %{jar_server: jar_server}} = request, response})
+         when jar_server != nil do
+      # req doesn't run request steps after a redirect again, but we need that to include any cookies
+      # that might have been returned in the redirect response for the next request
+      #
+      # Wojtek suggested this as a workaround until there is a better solution
+      request = %{
+        request
+        | current_request_steps: request.current_request_steps ++ [:add_cookies]
+      }
+
+      headers =
+        Enum.flat_map(response.headers, fn {name, vals} ->
+          Enum.map(vals, &{name, &1})
+        end)
+
+      HttpCookie.Jar.Server.put_cookies_from_headers(jar_server, request.url, headers)
+
+      {request, response}
+    end
+
+    defp update_cookies({request, response}), do: {request, response}
+  end
+end

--- a/test/http_cookie/req_server_test.exs
+++ b/test/http_cookie/req_server_test.exs
@@ -1,0 +1,136 @@
+defmodule ReqServerTest do
+  use ExUnit.Case, async: true
+
+  alias HttpCookie.ReqServerPlugin
+  alias HttpCookie.Jar
+
+  test "end-to-end" do
+    plug =
+      fn
+        %{request_path: "/one"} = conn ->
+          conn
+          |> Plug.Conn.put_resp_header("set-cookie", "foo=bar")
+          |> Plug.Conn.resp(200, "Have a cookie")
+
+        %{request_path: "/two"} = conn ->
+          conn = Plug.Conn.fetch_cookies(conn)
+          assert conn.req_cookies == %{"foo" => "bar"}
+
+          conn
+          |> Plug.Conn.prepend_resp_headers([
+            {"set-cookie", "foo2=bar2"},
+            {"set-cookie", "foo3=bar3"}
+          ])
+          |> Plug.Conn.resp(200, "Have some more")
+
+        %{request_path: "/three"} = conn ->
+          conn = Plug.Conn.fetch_cookies(conn)
+          assert conn.req_cookies == %{"foo" => "bar", "foo2" => "bar2", "foo3" => "bar3"}
+
+          conn
+          |> Plug.Conn.resp(200, "No more cookies for you, come back one year")
+      end
+
+    {:ok, jar_server} = Jar.Server.start_link([])
+
+    req =
+      Req.new(base_url: "https://example.com", plug: plug)
+      |> ReqServerPlugin.attach(jar_server: jar_server)
+
+    assert %{status: 200} = Req.get!(req, url: "/one")
+    assert %{status: 200} = Req.get!(req, url: "/two")
+    assert %{status: 200} = Req.get!(req, url: "/three")
+
+    jar = Jar.Server.get_cookie_jar(jar_server)
+
+    assert %{
+             "example.com" => %{
+               cookies: %{
+                 {"foo", "/"} => _,
+                 {"foo2", "/"} => _,
+                 {"foo3", "/"} => _
+               }
+             }
+           } = jar.cookies
+  end
+
+  test "picks up cookies from redirect response" do
+    plug =
+      fn
+        %{request_path: "/redirect-me"} = conn ->
+          conn
+          |> Plug.Conn.put_resp_header("set-cookie", "redirected=yes")
+          |> Plug.Conn.put_resp_header("location", "/first-stop")
+          |> Plug.Conn.resp(302, "Go away")
+
+        %{request_path: "/first-stop"} = conn ->
+          conn = Plug.Conn.fetch_cookies(conn)
+          assert conn.req_cookies == %{"redirected" => "yes"}
+
+          conn
+          |> Plug.Conn.put_resp_header("set-cookie", "stopped=yeah")
+          |> Plug.Conn.put_resp_header("location", "/final-destination")
+          |> Plug.Conn.resp(302, "Almost there")
+
+        %{request_path: "/final-destination"} = conn ->
+          conn = Plug.Conn.fetch_cookies(conn)
+          assert conn.req_cookies == %{"redirected" => "yes", "stopped" => "yeah"}
+
+          Plug.Conn.resp(conn, 200, "You made it!")
+      end
+
+    {:ok, jar_server} = Jar.Server.start_link([])
+
+    req =
+      Req.new(base_url: "https://example.com", plug: plug)
+      |> ReqServerPlugin.attach(jar_server: jar_server)
+
+    assert %{status: 200} = Req.get!(req, url: "/redirect-me")
+
+    jar = Jar.Server.get_cookie_jar(jar_server)
+
+    assert %{
+             "example.com" => %{
+               cookies: %{
+                 {"redirected", "/"} => _,
+                 {"stopped", "/"} => _
+               }
+             }
+           } = jar.cookies
+  end
+
+  test "doesn't override existing cookie header" do
+    plug =
+      fn
+        %{request_path: "/redirect-me"} = conn ->
+          conn
+          |> Plug.Conn.put_resp_header("set-cookie", "redirected=yes")
+          |> Plug.Conn.put_resp_header("location", "/first-stop")
+          |> Plug.Conn.resp(302, "Go away")
+
+        %{request_path: "/first-stop"} = conn ->
+          conn = Plug.Conn.fetch_cookies(conn)
+          assert conn.req_cookies == %{"there-can-only-be" => "one"}
+
+          conn
+          |> Plug.Conn.put_resp_header("set-cookie", "stopped=yeah")
+          |> Plug.Conn.put_resp_header("location", "/final-destination")
+          |> Plug.Conn.resp(302, "Almost there")
+
+        %{request_path: "/final-destination"} = conn ->
+          conn = Plug.Conn.fetch_cookies(conn)
+          assert conn.req_cookies == %{"there-can-only-be" => "one"}
+
+          Plug.Conn.resp(conn, 200, "You made it!")
+      end
+
+    {:ok, jar_server} = Jar.Server.start_link([])
+
+    req =
+      Req.new(base_url: "https://example.com", plug: plug)
+      |> ReqServerPlugin.attach(jar_server: jar_server)
+
+    assert %{status: 200} =
+             Req.get!(req, url: "/redirect-me", headers: [cookie: "there-can-only-be=one"])
+  end
+end


### PR DESCRIPTION
This pull request to add `Jar.Server` support to `Req` plugin.

For my usage, it feels easier to use a common Jar.Server for multiple requests without relying on passing the jar for each request. 

