### PR TITLE
Fixed Elixir 1.20 compilation warnings

### DIFF
--- a/lib/http_cookie.ex
+++ b/lib/http_cookie.ex
@@ -147,8 +147,8 @@ defmodule HttpCookie do
   """
   @spec update_last_access_time(cookie :: t()) :: t()
   @spec update_last_access_time(cookie :: t(), DateTime.t()) :: t()
-  def update_last_access_time(cookie, now \\ DateTime.utc_now()) do
-    %__MODULE__{cookie | last_access_time: now}
+  def update_last_access_time(%__MODULE__{} = cookie, now \\ DateTime.utc_now()) do
+    %{cookie | last_access_time: now}
   end
 
   @doc false

--- a/lib/http_cookie/date_parser.ex
+++ b/lib/http_cookie/date_parser.ex
@@ -4,8 +4,6 @@
 defmodule HttpCookie.DateParser do
   @moduledoc false
 
-  require Logger
-
   defmodule State do
     @moduledoc false
     defstruct ~w[time day_of_month month year]a


### PR DESCRIPTION
Hi,

This PR fixes the compilation warnings raised by Elixir `1.20.0-rc.1`.

### Warnings

```
mix compile --force
Compiling 9 files (.ex)
    warning: unused require Logger
    │
  7 │   require Logger
    │   ~
    │
    └─ lib/http_cookie/date_parser.ex:7:3

     warning: a struct for HttpCookie is expected on struct update:

         %HttpCookie{cookie | last_access_time: now}

     but got type:

         dynamic()

     where "cookie" was given the type:

         # type: dynamic()
         # from: lib/http_cookie.ex:150:31
         cookie

     when defining the variable "cookie", you must also pattern match on "%HttpCookie{}".

     hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

         user = some_function()
         %User{user | name: "John Doe"}

     it is enough to write:

         %User{} = user = some_function()
         %{user | name: "John Doe"}

     typing violation found at:
     │
 151 │     %__MODULE__{cookie | last_access_time: now}
     │     ~
     │
     └─ lib/http_cookie.ex:151:5: HttpCookie.update_last_access_time/2

Generated http_cookie app
```

### Setup

```sh
mise use erlang@28.3.1 elixir@1.20.0-rc.1-otp-28
```